### PR TITLE
Add Ordering and Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Table of contents:
 - [API Documentation](#api-documentation)
   * [GET `/entry/<entry-slug>.json`](#get---entry--entry-slug-json-)
     + [Examples](#examples)
-  * [GET `/entry/<entry-slug>/<filename>`](#get---entry--entry-slug---filename--)
+  * [GET `/entry/<entry-slug>/<filename>`](#get---entry--entry-slug---fialename--)
     + [Examples](#examples-1)
   * [GET `/all`](#get---all-)
   * [GET `/search`](#get---search-)
     + [Examples](#examples-2)
   * [Pagination](#pagination)
+  * [Sort and order by](#sort-and-order-by)
 - [Deploy](#deploy)
   * [Synchronising the database](#synchronising-the-database)
   * [Legacy](#legacy)
@@ -134,6 +135,24 @@ The following values are always present in responses, related to the given query
 - `page_total` - Total pages
 - `page_current` - Current page. This can be different from the requested page (using the `page` query param) when the number is invalid or out of the range 0..`page-total`.
 - `page_elements` - Elements per page. This can be customised (in the allowed range 1..10) by passing the `page_elements` query param.
+
+
+### Sort and order by
+This API supports sort and order operations, you just need to specify these query params while doing requests (respectively `sort` and `order_by`).
+
+`order_by` could assume these values:
+- `slug`
+- `title`
+
+`sort` is intended to be used with `order_by` and could assume the following values:
+- `asc`: enabled by default, ascending order
+- `desc`: descending order
+
+Example:
+```bash
+# Get every game in the homebrewhub ordered by title in a descending order:
+curl hh2.gbdev.io/api/all?order_by=title&sort=desc
+```
 
 ## Deploy
 

--- a/hhub/views.py
+++ b/hhub/views.py
@@ -20,7 +20,24 @@ def entry_manifest(request, pk):
 
 
 def entries_all(request):
+    sort_by = request.GET.get('sort_by', 1)
+    order_by = request.GET.get('order_by', 1)
+
     entries = Entry.objects.all()
+
+    # sort and order
+    # it would be meaningless to have a sort without an order
+    # order_by a specific field from schema
+    if order_by != 1 and order_by != "":
+        # specify an order --> asc is by default, so we're not dealing with it
+        if sort_by != 1 and sort_by != "" and sort_by.lower() != "asc":
+            entries = entries.order_by("-" + order_by.lower())  # order_by desc order
+        else:
+            entries = entries.order_by(order_by.lower())        # by default: sort by asc order
+    else:
+        # TODO: should we notify the user about a malformed query in case of empty order_by param? e.g. /api/all?order_by=&page=2
+        pass
+
     paginator = Paginator(entries, 10)
     page = request.GET.get('page', 1)
     results = len(entries)

--- a/hhub/views.py
+++ b/hhub/views.py
@@ -20,7 +20,7 @@ def entry_manifest(request, pk):
 
 
 def entries_all(request):
-    sort_by_param = request.GET.get('sort_by', '')
+    sort_by_param = request.GET.get('sort', '')
     order_by_param = request.GET.get('order_by', '')
 
     entries = Entry.objects.all()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44711271/134388972-7546730d-5921-497c-a716-00f696125211.png)

They are _almost_ the same.

Anyway, just docs is missing, we must document "sort_by" and "order_by" in README (even if it's pretty self-explanatory)

- order_by: give the result set ordering by a certain field. Fields are the columns of the database. It is the classic order_by SQL operation.

- sort_by: to use in conjuction with order_by, allowed fields <asc, desc>


Solves https://github.com/gbdev/homebrewhub/issues/21
