### PR TITLE
Update sync_db script location and updated README instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,124 @@
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mypy
+.mypy_cache/
+
+# vscode
+.vscode/
+
+# sqlite
+db.sqlite3
+db.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.9-slim-buster
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV LANGUAGE en_US:en
+ENV LANG en_US.UTF-8
+
+# Set work directory
+WORKDIR /src
+
+# Update and install system-level dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev
+
+
+# Install application-level dependencies
+COPY requirements.txt /src/
+RUN pip --disable-pip-version-check install -r requirements.txt
+
+# Copy project files over to image
+COPY . /src/
+
+# Expose 8000 port in container for Django use
+EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ On Linux, this command should install all requirements:
 apt install python3 libpq-dev python3-dev python3-venv
 ```
 
-Next, install Postgres 12 ([download link](https://www.postgresql.org/download/)), create a user, password and an `hh` table. Have it running in the background on port `5432`.
+Next, install Postgres 12 ([download link](https://www.postgresql.org/download/)), create a user, password and a database named `hh`. Have it running in the background on port `5432`.
 
 After that, follow the steps below to get started running the project manually:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of contents:
   - [Pagination](#pagination)
   - [Sort and order by](#sort-and-order-by)
 - [Deploy](#deploy)
-  - [Synchronising the database](#synchronising-the-database)
+  - [Synchronising the database](#synchronizing-the-database)
   - [Legacy](#legacy)
 
 ---
@@ -166,15 +166,23 @@ apt install python3 libpq-dev python3-dev python3-venv
 Here's how to quickly get started:
 
 ```bash
+
+# Start up backing services (database and database admin)
+# NOTE: Remember to run "docker-compose down" afterwards
+docker-compose up --detach
+
 # Set up a virtual env
 python3 -m venv env
+
 # Activate it
 source env/bin/activate
+
 # Install Python dependencies
 pip install -r requirements.txt
 
 # Prepare migrations for our Entry model
 python3 manage.py makemigrations hhub
+
 # Sync the database for the first time
 python3 manage.py migrate
 
@@ -186,7 +194,7 @@ git clone https://github.com/gbadev-org/games database-gba
 
 
 # Populate with the entries from the database repository
-python3 sync_db.py
+python3 manage.py runscript sync_db
 
 # Start the Django app
 python3 manage.py runserver
@@ -195,9 +203,9 @@ python3 manage.py runserver
 curl https://localhost:8000/all
 ```
 
-### Synchronising the database
+### Synchronizing the database
 
-The Homebrew Hub "source" database is simply a collection of folders, hosted as a git repository, each one containing an homebrew entry (ROM, screenshots, ..) and a "game.json" manifest file providing more details and metadata in a _consisting_ way (see the game.json JSON schema).
+The Homebrew Hub "source" database is simply a collection of folders, hosted as a git repository, each one containing an homebrew entry (ROM, screenshots, ..) and a "game.json" manifest file providing more details and metadata in a _consistent_ way (see the game.json JSON schema).
 
 For more information check the ["database" repository](https://github.com/gbdev/database) documentation.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of contents:
   - [Pagination](#pagination)
   - [Sort and order by](#sort-and-order-by)
 - [Deploy](#deploy)
-  - [Synchronising the database](#synchronizing-the-database)
+  - [Synchronising the database](#synchronising-the-database)
   - [Legacy](#legacy)
 
 ---
@@ -203,7 +203,7 @@ python3 manage.py runserver
 curl https://localhost:8000/all
 ```
 
-### Synchronizing the database
+### Synchronising the database
 
 The Homebrew Hub "source" database is simply a collection of folders, hosted as a git repository, each one containing an homebrew entry (ROM, screenshots, ..) and a "game.json" manifest file providing more details and metadata in a _consistent_ way (see the game.json JSON schema).
 

--- a/README.md
+++ b/README.md
@@ -151,25 +151,29 @@ Example:
 curl hh3.gbdev.io/api/all?order_by=title&sort=desc
 ```
 
-## Deploy
+## Local Development
 
-### Requirements
+There are two options for running this project locally: manually or using Docker.
 
-You need Python 3 and a couple of packages to build psycopg2:
+### Manual requirements
 
+You need Python 3 and a couple of packages to build `psycopg2` (database driver):
+
+On Linux, this command should install all requirements:
 ```bash
 apt install python3 libpq-dev python3-dev python3-venv
 ```
 
-### Run server
+Next, install Postgres 12 ([download link](https://www.postgresql.org/download/)), create a `hh` table and have it running in the background.
 
-Here's how to quickly get started:
+After that, follow the steps below to get started running the project manually:
 
 ```bash
+# Clone the repo locally
+git clone https://github.com/gbdev/homebrewhub
 
-# Start up backing services (database and database admin)
-# NOTE: Remember to run "docker-compose down" afterwards
-docker-compose up --detach
+# Change into the cloned repo
+cd homebrewhub
 
 # Set up a virtual env
 python3 -m venv env
@@ -192,15 +196,44 @@ git clone https://github.com/gbdev/database/
 # GBA
 git clone https://github.com/gbadev-org/games database-gba
 
-
 # Populate with the entries from the database repository
-python3 manage.py runscript sync_db
+DATABASE_URL=postgres://yourpostgresuserhere:yourpostgrespasswordhere@localhost:5432/hh python3 manage.py runscript sync_db
 
 # Start the Django app
-python3 manage.py runserver
+DATABASE_URL=postgres://yourpostgresuserhere:yourpostgrespasswordhere@localhost:5432/hh python3 manage.py runserver
 
-# Query the /all route to see if everything's there
-curl https://localhost:8000/all
+# In another terminal, query the /api/all route to see if everything's there
+curl https://localhost:8000/api/all
+```
+
+### Docker based requirements
+
+
+
+
+First, install Docker ([download link](https://docs.docker.com/get-docker/)).
+
+After that, follow the steps below to get started running the project using containers:
+
+```bash
+# Clone the repo locally
+git clone https://github.com/gbdev/homebrewhub
+
+# Change into the cloned repo
+cd homebrewhub
+
+# Clone the database repositories
+# GB/GBC
+git clone https://github.com/gbdev/database/
+# GBA
+git clone https://github.com/gbadev-org/games database-gba
+
+# Start up backing services (web server, database and database admin)
+# NOTE: This command will also take care of synchronising the database
+docker-compose up --build
+
+# Once that's finished, in another terminal, query the /api/all route to see if everything's there
+curl https://localhost:8000/api/all
 ```
 
 ### Synchronising the database
@@ -216,7 +249,7 @@ The "real" database needs to be built (and updated when a commit gets pushed) fr
 > Keep in mind that the two are not equivalent, as the Django database will keep additional values about each entry (e.g. simple analytics).
 
 ```sh
-python manage.py runscript sync-db
+python3 manage.py runscript sync_db
 ```
 
 ### Legacy

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ There are two options for running this project locally: manually or using Docker
 
 ### Manual requirements
 
-You need Python 3 and a couple of packages to build `psycopg2` (database driver):
+You need Python 3 and a couple of packages to build `psycopg2` (database driver).
 
 On Linux, this command should install all requirements:
 ```bash
 apt install python3 libpq-dev python3-dev python3-venv
 ```
 
-Next, install Postgres 12 ([download link](https://www.postgresql.org/download/)), create a `hh` table and have it running in the background.
+Next, install Postgres 12 ([download link](https://www.postgresql.org/download/)), create a user, password and an `hh` table. Have it running in the background on port `5432`.
 
 After that, follow the steps below to get started running the project manually:
 
@@ -199,6 +199,9 @@ git clone https://github.com/gbadev-org/games database-gba
 # Populate with the entries from the database repository
 DATABASE_URL=postgres://yourpostgresuserhere:yourpostgrespasswordhere@localhost:5432/hh python3 manage.py runscript sync_db
 
+# Optional note: You can export the environment variable to avoid typing it each time:
+EXPORT DATABASE_URL=postgres://yourpostgresuserhere:yourpostgrespasswordhere@localhost:5432/hh
+
 # Start the Django app
 DATABASE_URL=postgres://yourpostgresuserhere:yourpostgrespasswordhere@localhost:5432/hh python3 manage.py runserver
 
@@ -229,7 +232,7 @@ git clone https://github.com/gbdev/database/
 git clone https://github.com/gbadev-org/games database-gba
 
 # Start up backing services (web server, database and database admin)
-# NOTE: This command will also take care of synchronising the database
+# NOTE: This command will also take care of synchronising the database (including migrations)
 docker-compose up --build
 
 # Once that's finished, in another terminal, query the /api/all route to see if everything's there
@@ -244,7 +247,7 @@ For more information check the ["database" repository](https://github.com/gbdev/
 
 This enables the database to be "community-maintained", allowing everyone to add new entries (manually or by writing scrapers) or improve existing ones simply by opening Pull Requests.
 
-The "real" database needs to be built (and updated when a commit gets pushed) from this collection of folders. This job is done by the **sync-db.py** script.
+The "real" database needs to be built (and updated when a commit gets pushed) from this collection of folders. This job is done by the **sync_db.py** script.
 
 > Keep in mind that the two are not equivalent, as the Django database will keep additional values about each entry (e.g. simple analytics).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       retries: 50
     ports:
       - "5432:5432"
+
   pgadmin:
     container_name: hh_pgadmin
     image: dpage/pgadmin4
@@ -31,6 +32,23 @@ services:
     ports:
       - "5050:80"
     restart: unless-stopped
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: dev_web_start
+    entrypoint: /src/docker-entrypoint.sh
+    environment:
+      - DJANGO_SETTINGS_MODULE=hhub.settings
+      - DATABASE_URL=postgres://postgres:overwritethisinprod!@db:5432/hh
+    restart: on-failure
+    volumes:
+      - .:/src
+    ports:
+      - "8000:8000"
+    links:
+      - db:db
 
 volumes:
   postgres:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Wait for postgres DB to be ready before continuing
+postgres_ready() {
+    python manage.py shell << END
+import sys
+import psycopg2
+from django.db import connections
+try:
+  connections['default'].cursor()
+except psycopg2.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+END
+}
+
+until postgres_ready; do
+      >&2 echo "==> Waiting for Postgres..."
+      sleep 1
+    done
+
+case "$1" in
+  "dev_web_start")
+    echo "==> Creating migrations..."
+    python manage.py makemigrations
+
+    echo "==> Running migrations..."
+    python manage.py migrate
+
+    echo "==> Syncing database..."
+    python manage.py runscript sync_db
+
+    echo "==> Running web dev server..."
+    python manage.py runserver 0.0.0.0:8000
+    ;;
+
+  *)
+    exec "$@"
+    ;;
+esac

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,7 @@ until postgres_ready; do
 case "$1" in
   "dev_web_start")
     echo "==> Creating migrations..."
-    python manage.py makemigrations
+    python manage.py makemigrations hhub
 
     echo "==> Running migrations..."
     python manage.py migrate

--- a/hhub/settings.py
+++ b/hhub/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from pathlib import Path
+import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,7 +27,7 @@ SECRET_KEY = "REPLACE_ME"
 DEBUG = True
 
 # Allow the API to be served over the following hostnames:
-ALLOWED_HOSTS = ["127.0.0.1", "hh3.gbdev.io", "localhost"]
+ALLOWED_HOSTS = ["127.0.0.1", "hh3.gbdev.io", "localhost", "0.0.0.0"]
 
 # Allow the following hosts to consume the API
 CORS_ALLOWED_ORIGINS = [
@@ -86,13 +87,9 @@ WSGI_APPLICATION = "hhub.wsgi.application"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "HOST": "0.0.0.0",
-        "NAME": "hh",
-        "USER": "postgres",
-        "PASSWORD": "overwritethisinprod!",
-    }
+    "default": dj_database_url.config(
+        default="postgres://postgres:overwritethisinprod!@0.0.0.0:5432/hh"
+    )
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 asgiref==3.4.1
+dj-database-url==1.0.0
 Django==3.2.14
+django-cors-headers==3.10.0
+django-extensions==3.1.5
 djangorestframework==3.12.4
 psycopg2==2.9.1
 pytz==2021.1
 sqlparse==0.4.2
-django-cors-headers==3.10.0 
-django-extensions==3.1.5 

--- a/scripts/sync_db.py
+++ b/scripts/sync_db.py
@@ -49,7 +49,12 @@ def run():
 
                 romfile = ""
 
-                for file in data.get("files", []):
+                # Safety check to protect against entry without file (against schema)
+                if "files" not in data:
+                    print("Entry missing 'files' key, skipping...")
+                    continue
+
+                for file in data["files"]:
                     if "playable" in file:
                         romfile = file["filename"]
 
@@ -81,6 +86,8 @@ def run():
                     print("Warning: no title")
                     data["title"] = ""
 
+            # Returns an (entry, bool) tuple. Here we don't need the object that was
+            # either updated or created, we only want to know if it was created or not
             _, created = Entry.objects.update_or_create(
                 slug=data["slug"],
                 defaults=dict(

--- a/scripts/sync_db.py
+++ b/scripts/sync_db.py
@@ -12,17 +12,44 @@ from hhub.models import Entry
 dirs = ["database/entries", "database-gba/entries"]
 
 
+def _get_sha1_hash(game, romfile):
+    try:
+        sha1sum = hashlib.sha1()
+
+        with open(f"database/entries/{game}/{romfile}", "rb") as source:
+            block = source.read(2**16)
+
+            while len(block) != 0:
+                sha1sum.update(block)
+                block = source.read(2**16)
+
+        sha1 = sha1sum.hexdigest()
+        print("SHA1:", sha1)
+        return sha1
+
+    except Exception:
+        return ""
+
+
 def run():
     inserted = 0
     updated = 0
+
     for folder in dirs:
         print(f"Processing folder {folder}")
         games = os.listdir(folder)
-        for game in games:
+
+        games_count = len(games)
+        print(f"Found {games_count} games")
+
+        for n, game in enumerate(games, start=1):
             with open(f"{folder}/{game}/game.json") as json_file:
                 data = json.load(json_file)
-                print(f"Processing entry {game}")
-                for file in data["files"]:
+                print(f"({n}/{games_count}) Processing entry {game}")
+
+                romfile = ""
+
+                for file in data.get("files", []):
                     if "playable" in file:
                         romfile = file["filename"]
 
@@ -35,36 +62,28 @@ def run():
                 except Exception:
                     tools = ""
 
-                try:
-                    sha1sum = hashlib.sha1()
-                    with open(f"database/entries/{game}/{romfile}", 'rb') as source:
-                        block = source.read(2**16)
-                        while len(block) != 0:
-                            sha1sum.update(block)
-                            block = source.read(2**16)
-                        sha1 = sha1sum.hexdigest()
-                        print("SHA1:", sha1)
-                except Exception:
-                    sha1 = ""
+                _get_sha1_hash(game, romfile)
 
                 if "tags" not in data:
                     data["tags"] = []
+
                 if "platform" not in data:
                     print("no platform")
                     data["platform"] = "GB"
+
                 if "developer" not in data:
                     data["developer"] = ""
+
                 if "typetag" not in data:
                     data["typetag"] = "game"
+
                 if "title" not in data:
                     print("Warning: no title")
                     data["title"] = ""
 
-            try:
-                # Check if an entry already exists with the given slug
-                entry = Entry.objects.get(slug=data["slug"])
-                # And update its values
-                entry = Entry(
+            _, created = Entry.objects.update_or_create(
+                slug=data["slug"],
+                defaults=dict(
                     slug=data["slug"],
                     platform=data["platform"],
                     developer=data["developer"],
@@ -73,22 +92,12 @@ def run():
                     tags=data["tags"],
                     basepath=folder,
                     devtoolinfo=tools,
-                )
-                updated += 1
-            except Exception:
-                # otherwise, create a new entry
-                entry = Entry(
-                    slug=data["slug"],
-                    platform=data["platform"],
-                    developer=data["developer"],
-                    typetag=data["typetag"],
-                    title=data["title"],
-                    tags=data["tags"],
-                    basepath=folder,
-                    devtoolinfo=tools,
-                )
-                inserted += 1
+                ),
+            )
 
-            entry.save()
+            if created:
+                inserted +=1
+            else:
+                updated +=1
 
     print(f"{inserted} new entries inserted, {updated} updated")


### PR DESCRIPTION
The instructions for running `sync_db` were not working since `runscript` expects to find scripts in a `script/` folder at the root of the directory! Updated the README with the flow that worked for me when setting up locally.


I also tweaked the script (just a little bit) to reduce some lines. 
