### PR TITLE
Fix Table of contents anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Table of contents:
 
 - [API Documentation](#api-documentation)
 - [Local Development](#local-development)
-  - [1. Prerequisites](#prerequisites)
-  - [2. Pull the games databases](#pull-the-games-databases)
+  - [1. Prerequisites](#1-prerequisites)
+  - [2. Pull the games databases](#2-pull-the-games-databases)
   - [3A. Docker based requirements](#3a-docker-based-requirements)
   - [3B. Manual requirements](#3b-manual-requirements)
   - [4. Synchronising the database](#4-synchronising-the-database)
-  - [5. Get the frontend running](#get-the-frontend-running)
+  - [5. Get the frontend running](#5-get-the-frontend-running)
 - [Legacy](#legacy)
 
 ## API Documentation


### PR DESCRIPTION
### What
Fixes Table of contents anchors in README

### How to test
1. Navigate to the [README](https://github.com/nickspaargaren/homebrewhub/tree/fix-table-of-contents-anchors?tab=readme-ov-file#hhub)
2. Click all 9 links in the "Table of contents" section and make sure they work.

### Note
I am looking to contribute to the [frontend](https://github.com/gbdev/virens) that's how I noticed the anchors not working.